### PR TITLE
Use correct values for shader flags

### DIFF
--- a/DirectXShaderModel/ShaderFlags.cs
+++ b/DirectXShaderModel/ShaderFlags.cs
@@ -17,8 +17,13 @@ namespace HlslDecompiler.DirectXShaderModel
         NoPreShader = 256,
         AvoidFlowControl = 512,
         PreferFlowControl = 1024,
-        EnableBackwardsCompatibility = 2048,
-        IEEEStrictness = 4096,
-        UseLegacyD3DX931Dll = 8192
+        EnableStrictness = 2048,
+        EnableBackwardsCompatibility = 4096,
+        IEEEStrictness = 8192,
+        OptimizationLevel0 = 16384,
+        OptimizationLevel1 = 0,
+        OptimizationLevel2 = 49152,
+        OptimizationLevel3 = 32768,
+        UseLegacyD3DX931Dll = 65536
     }
 }


### PR DESCRIPTION
I got these from a D3D header or from Wine's implementation of D3D, but that was months ago, so I don't remember which.

Either way, the old values were definitely wrong, and the new ones are definitely right.